### PR TITLE
Move to Ubuntu 14.04, remove apt add-on on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: trusty
 sudo: false
 node_js:
   - "5.0.0"
@@ -11,11 +12,5 @@ services:
 addons:
   code_climate:
     repo_token: 6c3a1b81a09b2338d6f30913c1bcad115026689752cbb499a0a25061cda6fbcf
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - gcc-4.8
-    - g++-4.8
 after_script:
   - grunt coverage


### PR DESCRIPTION
This change seems to not fit the origin pull request template format, I just briefly describe the two reasons to move to Ubuntu 14.04 and remove the apt add-on on Travis CI:

1) Ubuntu Precise is reaching EOL, though Travis CI may take care of it.
we still can move to Trusty earlier as I didn't see any dependency of
Precise here.

2) GCC 4.8 is built-in in Travis CI's Ubuntu Trusty environment, which
means we don't need to spend time on adding ppa repository, apt update
and apt install, will save time on the CI.

Thanks.

Ref:
https://docs.travis-ci.com/user/trusty-ci-environment/#Compilers-%26-Build-toolchain