### PR TITLE
Fix docker installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Your application should run on port 3000 or the port you specified in your .env 
 
 ## Deploying with Docker
 
-To deploy with docker, first install docker [https://docs.docker.com/engine/installation/](here). 
+To deploy with docker, first install docker [here](https://docs.docker.com/engine/installation/). 
 
 Then run these commands
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The docker installation link used `[https://docs.docker.com/engine/installation/](here)` instead of `[here](https://docs.docker.com/engine/installation/)` and hence the link pointed to `https://github.com/tellform/tellform/blob/master/here` which is not the intended destination.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Points to the correct docker installation link.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

