### PR TITLE
Docker-Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  tellform:
+    image: tellform/production:no_subdomains
+    ports:
+      - 3000:3000
+      - 8080:80
+    links:
+      - redis:redis-db
+      - mongo:db
+    environment:
+      - BASE_URL=localhost
+      - DB_1_PORT_27017_TCP_ADDR=mongo
+      - REDIS_DB_PORT_6379_TCP_ADDR=redis
+  redis:
+    image: redis:alpine
+    ports:
+      - 6379
+  mongo:
+    image: mongo:latest
+    ports:
+      - 27017


### PR DESCRIPTION
A Docker-Compose file to make easy to deploy a Tellform server as Docker container

I want to use Tellform on-premisses, and the documented docker run commands don't run to me. Then I stress to work and put all my efforts to a docker-compose.yml file.

Docker Compose will be in charge to up the Tellform server and its dependencies.

Command: `docker-compose up -d`