### PR TITLE
Enforce npm engines checking via check-node-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: false
 node_js:
   - "5.0.0"
-  - "4.0.0"
+  - "6.0.0"
 env:
   - NODE_ENV=travis TRAVIS=travis CXX=g++-4.8
 services:

--- a/package.json
+++ b/package.json
@@ -13,20 +13,19 @@
     "url": "https://github.com/whitef0x0/tellform.git"
   },
   "engines": {
-    "node": "~5.0.0",
-    "npm": "~2.11.2"
+    "node": ">=5.0.0",
+    "npm": ">=2.11.2"
   },
   "scripts": {
     "addcontrib": "all-contributors add",
     "generate": "all-contributors generate",
-    "start": "grunt",
-    "test": "grunt test",
+    "start": "npm run version && grunt",
+    "test": "npm run version && grunt test",
     "postinstall": "bower install --config.interactive=false; grunt build;",
-    "init": "node scripts/setup.js"
+    "init": "node scripts/setup.js",
+    "version": "check-node-version --package"
   },
   "dependencies": {
-    "multer": "^1.3.0",
-    "glob": "^7.0.3",
     "async": "^1.4.2",
     "async-boolean-expression-evaluator": "^1.1.1",
     "bcrypt": "^0.8.7",
@@ -34,6 +33,7 @@
     "body-parser": "~1.14.1",
     "bower": "~1.6.5",
     "chalk": "^1.1.3",
+    "check-node-version": "^2.1.0",
     "compression": "~1.6.0",
     "connect": "^3.4.1",
     "connect-flash": "~0.1.1",
@@ -49,6 +49,7 @@
     "express-session": "~1.12.1",
     "forever": "~0.15.1",
     "fs-extra": "~0.26.2",
+    "glob": "^7.0.3",
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.13",
     "grunt-concurrent": "~2.3.0",
@@ -74,6 +75,7 @@
     "mongoose": "~4.4.19",
     "mongoose-utilities": "~0.1.1",
     "morgan": "~1.6.1",
+    "multer": "^1.3.0",
     "nodemailer": "~1.10.0",
     "nodemailer-sendgrid-transport": "^0.2.0",
     "nodemailer-sparkpost-transport": "^1.0.0",


### PR DESCRIPTION
## Description
Enforce engines (node and npm) checking inside in your module.

## Motivation and Context
It is required because sometimes you can run this app, with the incorrect node or npm version.
Also engines npm and node versions are outdated. 
(~ In the simplest terms, the tilde matches the most recent minor version (the middle number). ~1.2.3 will match all 1.2.x versions but will miss 1.3.0 )

## How Has This Been Tested?
Simple test locally with different version of node.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

