### PR TITLE
Fix up Heroku apps.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,10 +1,10 @@
 {
 	"name": "TellForm",
 	"description": "Beautiful, opensource web forms",
-	"repository": "https://github.com/whitef0x0/tellform",
-	"logo": "https://node-js-sample.herokuapp.com/node.svg",
+	"repository": "https://github.com/tellform/tellform",
+	"logo": "https://tellform.com/public/img/tellform_logo_black.png",
 	"keywords": ["node", "express", "static", "mean"],
-	"addons": ["mongolab", "sparkpost"],
+	"addons": ["mongolab", "sendgrid", "heroku-redis"],
 	"env": {
 		"SUBDOMAINS_DISABLED": {
 			"description": "Disable support for running subdomains. (This should be true if you are not using your own custom domain.",
@@ -26,7 +26,7 @@
 		},
 		"MAILER_SERVICE_PROVIDER": {
 			"description": "Which mail service/API you will be using (i.e. SparkPost, Mandrill, etc)",
-			"value": "Sparkpost"
+			"value": "SendGrid"
 		}
 	}
 }


### PR DESCRIPTION
## Description
Heroku's deploy button was broken and I fixed it up.

## Motivation and Context

1. SparkPost no longer offers free plan on Heroku https://elements.heroku.com/addons/sparkpost
2. Logo image url was broken
3. Repo URL is outdated

## How Has This Been Tested?

I merged the change on my fork and use it to deploy a new app on Herkou successfully.

## Screenshots (if appropriate):

<img width="1440" alt="screenshot 2017-06-28 12 42 22" src="https://user-images.githubusercontent.com/14349/27620915-89709dce-5bff-11e7-820d-1b40d32cda61.png">


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklis
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
