### PR TITLE
Fix user signup errors [wip]

### DIFF
--- a/app/controllers/errors.server.controller.js
+++ b/app/controllers/errors.server.controller.js
@@ -25,7 +25,9 @@ exports.getErrorMessage = function(err) {
 
 	if(!err) {
 		return '';
-	} else if (err.code) {
+	} else if(typeof err === 'string'){
+        message = err;
+    } else if (err.code) {
 		switch (err.code) {
 			case 11000:
 			case 11001:

--- a/app/controllers/users/users.authentication.server.controller.js
+++ b/app/controllers/users/users.authentication.server.controller.js
@@ -19,6 +19,7 @@ var config_nev = function () {
 	nev.configure({
 	    persistentUserModel: User,
 	    tempUserCollection: config.tempUserCollection,
+        emailAndUsernameUnique: true,
 	    expirationTime: 86400,  // 24 hours
 
 	    verificationURL: config.baseUrl+'/#!/verify/${URL}',
@@ -103,10 +104,10 @@ exports.signup = function(req, res) {
 
 	// Add missing user fields
 	user.provider = 'local';
-
 	// Then save the temporary user
 	nev.createTempUser(user, function (err, existingPersistentUser, newTempUser) {
-		if (err) {
+		debugger;
+        if (err) {
 			return res.status(400).send({
 				message: errorHandler.getErrorMessage(err)
 			});
@@ -125,6 +126,7 @@ exports.signup = function(req, res) {
 				return res.status(200).send('An email has been sent to you. Please check it to verify your account.');
 			});
 		} else {
+            console.log(err);
 			return res.status(400).send({message: 'Error: User already exists!'});
 		}
 	});

--- a/public/modules/users/views/authentication/signup.client.view.html
+++ b/public/modules/users/views/authentication/signup.client.view.html
@@ -26,7 +26,7 @@
 		<div class="col-xs-offset-3 col-xs-6 col-sm-offset-4 col-sm-4">
 			<form name="userForm" data-ng-submit="signup()" class="signin form-horizontal" autocomplete="off">
 				<fieldset>
-					<div data-ng-show="error" id="signup_errors" class="text-center text-danger">
+					<div data-ng-show="error" id="signup_errors" class="text-center">
 						{{'SIGNUP_ERROR_TEXT' | translate}}: <br>
 						<strong data-ng-bind="error"></strong>
 					</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing user signup errors so that we notify a user whether their username or email is already taken instead of just returning a general and vague "User already exists" message.

In a broader context, this PR is also about improving the UI of the errors as the contrast and design of the error messages for signup errors right now is quite ugly and hard to see. 

## Motivation and Context
This solves problems of users trying to signup with a username that is already taken and not realizing it.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

