### PR TITLE
Adding Custom SMTP Server Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 dist: trusty
 sudo: false
 node_js:
-  - "6.11.1"
+  - "6.11.2"
 env:
   - NODE_ENV=travis TRAVIS=travis CXX=g++-4.8
 services:

--- a/README.md
+++ b/README.md
@@ -83,12 +83,23 @@ OR create your .env file
 GOOGLE_ANALYTICS_ID=yourGAID
 PRERENDER_TOKEN=yourPrerender.ioToken
 COVERALLS_REPO_TOKEN=yourCoveralls.ioToken
-MAILER_EMAIL_ID=SMTP_Injection
-MAILER_FROM=noreply@yourdomain.com
-MAILER_PASSWORD=your_sendgrid_apikey
-MAILER_SERVICE_PROVIDER=SendGrid
 BASE_URL=localhost
 DSN_KEY=yourPrivateRavenKey
+
+# Mail config
+MAILER_EMAIL_ID=user@domain.com
+MAILER_PASSWORD=some-pass
+MAILER_FROM=user@domain.com
+
+# Use this for one of Nodemailer's pre-configured service providers
+MAILER_SERVICE_PROVIDER=SendGrid
+
+# Use these for a custom service provider 
+# Note: MAILER_SMTP_HOST will override MAILER_SERVICE_PROVIDER
+MAILER_SMTP_HOST=smtp.domain.com
+MAILER_SMTP_PORT=465
+MAILER_SMTP_SECURE=true
+
 ```
 
 Side note: ___Currently we are using Raven and Sentry [https://www.getsentry.com](https://www.getsentry.com) for error logging. To use it you must provide a valid private DSN key in your .env file and a public DSN key in app/views/layout.index.html___
@@ -174,7 +185,7 @@ $ bower install
 ```
 
 #### Prepare .env file:
-Create .env file at project root folder. Fill in MAILER_SERVICE_PROVIDER, MAILER_EMAIL_ID and MAILER_PASSWORD.
+Create .env file at project root folder. Fill in MAILER_EMAIL_ID and MAILER_PASSWORD, and either MAILER_SERVICE_PROVIDER using a [Nodemailer Well-known service](https://nodemailer.com/smtp/well-known/) or MAILER_SMTP_HOST, MAILER_SMTP_PORT, and MAILER_SMTP_SECURE for a custom SMTP server.
 ```
 APP_NAME=forma
 APP_DESC=
@@ -183,10 +194,6 @@ NODE_ENV=development
 BASE_URL=localhost:5000
 PORT=5000
 username=forma_admin
-MAILER_SERVICE_PROVIDER=
-MAILER_EMAIL_ID=
-MAILER_PASSWORD=
-MAILER_FROM=forma@data.gov.sg
 SIGNUP_DISABLED=false
 SUBDOMAINS_DISABLED=true
 DISABLE_CLUSTER_MODE=true
@@ -194,6 +201,20 @@ GOOGLE_ANALYTICS_ID=
 RAVEN_DSN=
 PRERENDER_TOKEN=
 COVERALLS_REPO_TOKEN=
+
+# Mail config
+MAILER_EMAIL_ID=forma@data.gov.sg
+MAILER_PASSWORD=some-pass
+MAILER_FROM=forma@data.gov.sg
+
+# Use this for one of Nodemailer's pre-configured service providers
+MAILER_SERVICE_PROVIDER=
+
+# Use these for a custom service provider 
+# Note: MAILER_SMTP_HOST will override MAILER_SERVICE_PROVIDER
+MAILER_SMTP_HOST=
+MAILER_SMTP_PORT=465
+MAILER_SMTP_SECURE=true
 ```
 
 #### Deploy with Docker:

--- a/app/controllers/users/users.authentication.server.controller.js
+++ b/app/controllers/users/users.authentication.server.controller.js
@@ -95,7 +95,6 @@ exports.resendVerificationEmail = function(req, res, next){
  * Signup
  */
 exports.signup = function(req, res) {
-
 	// For security measures we remove the roles from the req.body object
 	delete req.body.roles;
 
@@ -106,12 +105,12 @@ exports.signup = function(req, res) {
 	user.provider = 'local';
 	// Then save the temporary user
 	nev.createTempUser(user, function (err, existingPersistentUser, newTempUser) {
-		debugger;
-        if (err) {
+		if (err) {
 			return res.status(400).send({
 				message: errorHandler.getErrorMessage(err)
 			});
 		}
+
 
 		// new user created
 		if (newTempUser) {

--- a/app/models/user.server.model.js
+++ b/app/models/user.server.model.js
@@ -15,6 +15,14 @@ var mongoose = require('mongoose'),
 
 var smtpTransport = nodemailer.createTransport(config.mailer.options);
 
+// verify connection configuration on startup
+smtpTransport.verify(function(error, success) {
+	if (error) {
+			 console.log('Your mail configuration is incorrect', error);
+	} else {
+			 console.log('Mail server is ready to take our messages');
+	}
+});
 
 /**
  * A Validation function for local strategy properties

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -43,7 +43,15 @@ module.exports = {
 	},
 	mailer: {
 		from: process.env.MAILER_FROM || 'no-reply@tellform.com',
-		options: {
+		options: process.env.MAILER_SMTP_HOST ? { //Uses custom SMTP if MAILER_SMTP_HOST is set
+			host: process.env.MAILER_SMTP_HOST || '',
+			port: process.env.MAILER_SMTP_PORT || 465,
+			secure: process.env.MAILER_SMTP_SECURE || true,
+			auth: {
+				user: process.env.MAILER_EMAIL_ID || '',
+				pass: process.env.MAILER_PASSWORD || ''
+			}
+		} : {
 			service: process.env.MAILER_SERVICE_PROVIDER || '',
 			auth: {
 				user: process.env.MAILER_EMAIL_ID || '',

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -59,11 +59,19 @@ module.exports = {
 	},
 	mailer: {
 		from: process.env.MAILER_FROM || 'testing@'+process.env.SPARKPOST_SANDBOX_DOMAIN || 'no-reply@tellform.com',
-		options: {
+		options: process.env.MAILER_SMTP_HOST ? { //Uses custom SMTP if MAILER_SMTP_HOST is set
+			host: process.env.MAILER_SMTP_HOST || '',
+			port: process.env.MAILER_SMTP_PORT || 465,
+			secure: process.env.MAILER_SMTP_SECURE || true,
+			auth: {
+				user: process.env.MAILER_EMAIL_ID || '',
+				pass: process.env.MAILER_PASSWORD || ''
+			}
+		} : {
 			service: process.env.MAILER_SERVICE_PROVIDER || '',
 			auth: {
-				user: process.env.MAILER_EMAIL_ID || process.env.SPARKPOST_SMTP_USERNAME || '',
-				pass: process.env.MAILER_PASSWORD || process.env.SPARKPOST_SMTP_PASSWORD || ''
+				user: process.env.MAILER_EMAIL_ID || '',
+				pass: process.env.MAILER_PASSWORD || ''
 			}
 		}
 	}

--- a/config/env/secure.js
+++ b/config/env/secure.js
@@ -66,7 +66,15 @@ module.exports = {
 	},
 	mailer: {
 		from: process.env.MAILER_FROM || '',
-		options: {
+		options: process.env.MAILER_SMTP_HOST ? { //Uses custom SMTP if MAILER_SMTP_HOST is set
+			host: process.env.MAILER_SMTP_HOST || '',
+			port: process.env.MAILER_SMTP_PORT || 587,
+			secure: process.env.MAILER_SMTP_SECURE || true,
+			auth: {
+				user: process.env.MAILER_EMAIL_ID || '',
+				pass: process.env.MAILER_PASSWORD || ''
+			}
+		} : {
 			service: process.env.MAILER_SERVICE_PROVIDER || '',
 			auth: {
 				user: process.env.MAILER_EMAIL_ID || '',

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -52,7 +52,15 @@ module.exports = {
 	},
 	mailer: {
 		from: process.env.MAILER_FROM || 'MAILER_FROM',
-		options: {
+		options: process.env.MAILER_SMTP_HOST ? { //Uses custom SMTP if MAILER_SMTP_HOST is set
+			host: process.env.MAILER_SMTP_HOST || '',
+			port: process.env.MAILER_SMTP_PORT || 587,
+			secure: process.env.MAILER_SMTP_SECURE || true,
+			auth: {
+				user: process.env.MAILER_EMAIL_ID || '',
+				pass: process.env.MAILER_PASSWORD || ''
+			}
+		} : {
 			service: process.env.MAILER_SERVICE_PROVIDER || '',
 			auth: {
 				user: process.env.MAILER_EMAIL_ID || '',

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "mongoose-utilities": "~0.1.1",
     "morgan": "~1.8.1",
     "multer": "^1.3.0",
-    "nodemailer": "~1.10.0",
+    "nodemailer": "~4.0.0",
     "nodemailer-sendgrid-transport": "^0.2.0",
     "nodemailer-sparkpost-transport": "^1.0.0",
     "passport": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "https://github.com/whitef0x0/tellform.git"
   },
   "engines": {
-    "node": "6.11.1",
-    "npm": "3.3.6"
+    "node": "6.11.2",
+    "npm": "3.10.10"
   },
   "scripts": {
     "addcontrib": "all-contributors add",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

I've added the following env vars which will tell nodemailer to use smtp auth instead of a [Well-known service](https://nodemailer.com/smtp/well-known/)

```BASH
MAILER_SMTP_HOST=
MAILER_SMTP_PORT=465
MAILER_SMTP_SECURE=true
```


To do this, I simply check if the `MAILER_SMTP_HOST` var is set, and if so, change the `options` property of the mailer config object to use the correct option set for connecting any SMTP server as documented in the [Nodemailer docs](https://nodemailer.com/smtp/):

```javascript
	mailer: {
		from: process.env.MAILER_FROM || 'no-reply@tellform.com',
		options: process.env.MAILER_SMTP_HOST ? { //Uses custom SMTP if MAILER_SMTP_HOST is set
			host: process.env.MAILER_SMTP_HOST || '',
			port: process.env.MAILER_SMTP_PORT || 465,
			secure: process.env.MAILER_SMTP_SECURE || true,
			auth: {
				user: process.env.MAILER_EMAIL_ID || '',
				pass: process.env.MAILER_PASSWORD || ''
			}
		} : {
			service: process.env.MAILER_SERVICE_PROVIDER || '',
			auth: {
				user: process.env.MAILER_EMAIL_ID || '',
				pass: process.env.MAILER_PASSWORD || ''
			}
		}
	}
```

> Don't worry, I changed the above in all environments and made sure to keep the same formatting and fallback values for each respective env.

I also added a check on server start in `user.server.model.js` right after the nodemailer transporter is created that verifies the connection and logs if it's bad. To do this, I had to update nodemailer from version 1.x to 4.x. I did all of my testing after that upgrade, and ensured that `nodemailer-sendgrid-transport` and `nodemailer-sparkpost-transport` would still work. Luckily for us, nodemailer hasn't done much to break it's API _post_ 1.0.

```javascript
var smtpTransport = nodemailer.createTransport(config.mailer.options);

// verify connection configuration on startup
smtpTransport.verify(function(error, success) {
  if (error) {
    console.log('Your mail configuration is incorrect', error);
  } else {
    console.log('Mail server is ready to take our messages');
  }
});
```

I also changed the node/npm version checks in package.json from node `6.11.1` to `6.11.2` and npm from `3.6.6` to `3.10.10`. This is because the Dockerfile pulls the latest 6.x version, and of course npm wasn't too happy to start a server with mismatched node/npm version requirements:

```docker
# Install nodejs
RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
```

Finally, I removed a `debugger;` statement from the mailer which was causing my application to stop in it's tracks. I noticed it was the only place in the entire code base where `debugger;` appears, so I assume this isn't a critical logging feature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm deploying this in a restricted environment that can't use external mailing services (plus we just want to use the internal email server). Sadly, there's no way to effectively use this app on a multi-user level without email integration.

<!--- If it fixes an open issue, please link to the issue here. -->
[Here you go](https://github.com/tellform/tellform/issues/220)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've tested the following scenarios with both the Development and Production flags:

- Registration email alerts are sent with MailGun and Sendgrid using the same env file I used before making these changes
- Registration email alerts are sent with my new env variables using my own SMTP server if I provide a `MAILER_SMTP_HOST` env var
- Account creation works with both methods, verification emails are sent and I am able to create forms as usual with the newly created account
- When using incorrect credentials, either a bad API key _or_ a bad SMTP auth set, on server start I get a console warning

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
**The user will see this message if their service creds or smtp creds are invalid on server start:**
![bad-creds](https://cloud.wlan1.net/s/0xo5dx6f3gVhPSH/download)

**The user will see this message on server start if the mail server accepted their creds:**
![good-creds](https://cloud.wlan1.net/s/HK98L8lu6dCkisY/download)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

I've only checked Breaking change since the `debugger;` line was causing the app to never send emails, even with MailGun/SendGrid

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Note** I didn't add unit tests as there were none for the current mailing system.

The goal is that you can pull this and verify it still works with your exact env config as it is now. I absolutely don't want to put something up that requires users to change their config.
