### PR TITLE
Fixed ScrollSpy for fields

### DIFF
--- a/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
@@ -47,10 +47,9 @@
 						<div class="col-md-5 col-sm-9">{{ 'SHAPE' | translate }}:</div>
 						<div class="col-md-7 col-sm-3">
 							<select style="width:100%" ng-model="field.ratingOptions.shape"
-									ng-value="field.ratingOptions.steps"
 									name="ratingOptions_shape{{field._id}}" required>
 								<option ng-repeat="shapeType in validShapes"
-										ng-value="shapeType">
+										value="{{shapeType}}">
 									{{select2FA[shapeType]}}
 								</option>
 							</select>


### PR DESCRIPTION
This PR scraps the bespoke code written for this and instead uses angular-scroll to detect the element that the user has scrolled to.

## Motivation and Context
This fixes a long standing issue with detecting what the current field is based on the current scroll position. 

## How Has This Been Tested?
TODO

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

