### PR TITLE
Fix incorrect responses count for form list view

### DIFF
--- a/app/models/form.server.model.js
+++ b/app/models/form.server.model.js
@@ -203,7 +203,7 @@ var FormSchema = new Schema({
 	},
 
 	design: {
-		colors:{
+		colors: {
 			backgroundColor: {
 				type: String,
 				match: [/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/],

--- a/public/modules/forms/admin/views/list-forms.client.view.html
+++ b/public/modules/forms/admin/views/list-forms.client.view.html
@@ -88,7 +88,7 @@
 				</a>
 				<div class="col-xs-12 responses-row">
 					<small class="list-group-item-text">
-						<span> {{ form.numberOfResponses }} {{ 'RESPONSES' | translate }} </span>
+						<span> {{ form.submissionNum }} {{ 'RESPONSES' | translate }} </span>
 					</small>
 					<br>
 					<br>


### PR DESCRIPTION
This PR fixes the incorrect responses count for each form in the form list view.

## Description
This feature was broken when we stopped storing form submissions as subdocuments in the Form Schema. In order to improve performance we have used MongoDB's aggregration feature to quickly find the number of form submissions for all of a given users' forms.

## Motivation and Context
This is required as currently the responses count is not returning the correct count of submissions for each form in the form list view.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

