### PR TITLE
Fix wrong vendor.min.js file reference URL

### DIFF
--- a/app/views/form.server.view.pug
+++ b/app/views/form.server.view.pug
@@ -82,7 +82,7 @@ html(lang='en', xmlns='http://www.w3.org/1999/xhtml')
 
     //Minified Bower Dependencies
     script(src='/static/lib/angular/angular.min.js')
-    script(src='/static/dist/vendor.min.js')
+    script(src='/static/dist/form-vendor.min.js')
     script(src='/static/lib/angular-ui-date/src/date.js', type='text/javascript')
 
     //Application JavaScript Files


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Missing vendor.min.js url and hence not able to view forms http://forms.kenyaapps.net/view/#!/forms/form_id

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

