### PR TITLE
Add JSEP CDN

### DIFF
--- a/app/views/form.server.view.pug
+++ b/app/views/form.server.view.pug
@@ -59,6 +59,9 @@ html(lang='en', xmlns='http://www.w3.org/1999/xhtml')
       script(type='text/javascript').
         socketUrl = "!{socketUrl}"
 
+    //JSEP
+    script(src='https://cdn.jsdelivr.net/npm/jsep@0.3.4/build/jsep.min.js', type='text/javascript')
+
     script(src='/static/lib/jquery/dist/jquery.min.js', type='text/javascript')
     link(rel='stylesheet', href='/static/lib/font-awesome/css/font-awesome.min.css')
     link(rel='stylesheet', href='/static/lib/bootstrap/dist/css/bootstrap.min.css')


### PR DESCRIPTION
The form doesn't show up due to an error caused by inability to locate JSEP (see #298). We can fix this by adding the JSEP CDN to the form `pug` file:

``` diff
+   script(src='https://cdn.jsdelivr.net/npm/jsep@0.3.4/build/jsep.min.js', type='text/javascript')
```

This would fix #298 and allow forms to work again.