### PR TITLE
deleteSubmissions - remove spurious condition

### DIFF
--- a/app/controllers/forms.server.controller.js
+++ b/app/controllers/forms.server.controller.js
@@ -19,7 +19,7 @@ exports.deleteSubmissions = function(req, res) {
 	var submission_id_list = req.body.deleted_submissions,
 		form = req.form;
 
-	FormSubmission.remove({ form: req.form, admin: req.user, _id: {$in: submission_id_list} }, function(err){
+	FormSubmission.remove({ form: req.form, _id: {$in: submission_id_list} }, function(err){
 
 		if(err){
 			res.status(400).send({


### PR DESCRIPTION
## Description
`FormSubmission.remove` should not use `admin` as a condition:
 - the field is not present in the schema or in any created submissions
 - the user is unlikely to be the admin of a submission 

## Motivation and Context
This PR attempts to fix the bug by removing the spurious condition

Fixes #315

## How Has This Been Tested?
Owing to time pressures and the relative difficulty in setting up a test environment, I am reliant on the CI infrastructure set up by tellform. Affected functionality is already broken anyway.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

