### PR TITLE
Conflicting HTML element attributes

### DIFF
--- a/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
+++ b/public/modules/forms/admin/views/directiveViews/form/edit-form.client.view.html
@@ -497,7 +497,7 @@
             <h4 class="col-sm-12 hidden-xs hidden-md hidden-lg">{{ 'ADD_FIELD_MD' | translate }}</h4>
             <h5 class="col-xs-12 hidden-sm hidden-md hidden-lg">{{ 'ADD_FIELD_SM' | translate }}</h5>
         </div>
-        <div class="panel-group row" class="draggable" ng-model="addField.types">
+        <div class="panel-group row draggable" ng-model="addField.types">
 
             <div class="col-xs-12 col-sm-12 col-md-6" ng-repeat="type in addField.types" style="padding-top:7.5px;">
                 <div class="panel panel-default" style="background-color:#f5f5f5;">


### PR DESCRIPTION
If an HTML element has two attributes with the same name but different values, its behavior may be browser-dependent.

According to the HTML5 standard, an HTML element must not have two or more attributes with the same name. Elements that do not conform to this restriction may be interpreted differently by different browsers.
