### PR TITLE
Use of AngularJS markup in URL-valued attribute

### DIFF
--- a/public/form_modules/forms/base/views/directiveViews/entryPage/startPage.html
+++ b/public/form_modules/forms/base/views/directiveViews/entryPage/startPage.html
@@ -9,7 +9,7 @@
  <div class="row form-actions" style="padding-bottom:3em; padding-left: 1em; padding-right: 1em;">
     <p ng-repeat="button in pageData.buttons" class="text-center" style="display:inline;">
         <button class="btn btn-info" type="button" ng-style="{'background-color':button.bgColor, 'color':button.color}">
-            <a href="{{button.url}}" style="font-size: 1.6em; text-decoration: none; color: inherit;" >
+            <a ng-href="{{button.url}}" style="font-size: 1.6em; text-decoration: none; color: inherit;" >
                 {{button.text}}
             </a>
         </button>

--- a/public/form_modules/forms/base/views/directiveViews/form/submit-form.client.view.html
+++ b/public/form_modules/forms/base/views/directiveViews/form/submit-form.client.view.html
@@ -23,7 +23,7 @@
     <div class="row form-actions" style="padding-bottom:3em; padding-left: 1em; padding-right: 1em;">
         <p ng-repeat="button in myform.startPage.buttons" class="text-center" style="display:inline;">
             <button class="btn" style="background-color:rgb(156, 226, 235)" type="button" ng-style="{'background-color':button.bgColor, 'color':button.color}">
-				<a href="{{button.url}}"
+				<a ng-href="{{button.url}}"
 				style="font-size: 1.6em; text-decoration: none;"
 				ng-style="{'color':button.color}">
 				{{button.text}}
@@ -140,7 +140,7 @@
     <div class="row form-actions" style="padding-bottom:3em; padding-left: 1em; padding-right: 1em;">
         <p ng-repeat="button in myform.endPage.buttons" class="text-center" style="display:inline;">
             <button class="btn" style="background-color:rgb(156, 226, 235)" type="button" ng-style="{'background-color':button.bgColor, 'color':button.color}">
-				<a href="{{button.url}}"
+				<a ng-href="{{button.url}}"
 				   style="font-size: 1.6em; text-decoration: none;"
 				   ng-style="{'color':button.color}">
 					{{button.text}}

--- a/public/modules/forms/admin/views/admin-form.client.view.html
+++ b/public/modules/forms/admin/views/admin-form.client.view.html
@@ -41,7 +41,7 @@
 		</div>
 		<div class="col-xs-1 col-sm-2">
 			<small class="pull-right">
-				<a class="btn btn-secondary view-form-btn" href="{{actualFormURL}}">
+				<a class="btn btn-secondary view-form-btn" ng-href="{{actualFormURL}}">
 					<span class="hidden-xs hidden-sm">
 						{{ 'VIEW' | translate }}
 						<span ng-show="myform.isLive">
@@ -97,7 +97,7 @@
 												<span ngclipboard data-clipboard-target="#copyEmbedded">
 													<textarea id="copyEmbedded" class="form-control ng-pristine ng-untouched ng-valid" style="min-height:200px; width:100%; background-color: #FFFFCC; color: #30313F;">
 														&lt;!-- {{ 'CHANGE_WIDTH_AND_HEIGHT' | translate }} --&gt;
-														<iframe id="iframe" src="{{actualFormURL}}" style="width:100%;height:500px;"></iframe>
+														<iframe id="iframe" ng-src="{{actualFormURL}}" style="width:100%;height:500px;"></iframe>
 														<div style="font-family: Sans-Serif;font-size: 12px;color: #999;opacity: 0.5; padding-top: 5px;">{{ 'POWERED_BY' | translate }} <a href="https://www.tellform.com" style="color: #999" target="_blank">TellForm</a></div>
 													</textarea>
 												</span>


### PR DESCRIPTION
Using AngularJS markup in an HTML attribute that references a URL (such as 'href' or 'src') may cause the browser to send a request with an invalid URL.

Using AngularJS markup (that is, AngularJS expressions enclosed in double curly braces) in HTML attributes that reference URLs is not recommended: the browser may attempt to fetch the URL before the AngularJS compiler evaluates the markup, resulting in a request for an invalid URL.

While this is not a serious problem, it can degrade user experience, since the page may, for example, display broken image links while loading.